### PR TITLE
1. 열거타입명 수정 eType -> eCampType

### DIFF
--- a/Assets/Scenes/HaxGameScene.unity
+++ b/Assets/Scenes/HaxGameScene.unity
@@ -7013,7 +7013,7 @@ MonoBehaviour:
     tilePrefab: {fileID: 2149083520097030585, guid: aed7254c2ac20564084f42982358dded,
       type: 3}
     parent: {fileID: 1139358907}
-    width: 8
+    width: 9
     hegiht: 6
   battleGrid:
     tilePrefab: {fileID: 2149083520097030585, guid: 9be100eb0ecb9024994b53134d1af74f,

--- a/Assets/Scripts/Common/SO/TileItemSO.cs
+++ b/Assets/Scripts/Common/SO/TileItemSO.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 [System.Serializable]
 public class TileItem
 {
-    public enum eType
+    public enum eCampType
     {
         None = 0,
         Base = 1,
@@ -19,7 +19,7 @@ public class TileItem
     }
 
     public string name;
-    public eType type;
+    public eCampType type;
     public Sprite sprite;
     public int moveCost;
 }

--- a/Assets/Scripts/HexPack/GameManager.cs
+++ b/Assets/Scripts/HexPack/GameManager.cs
@@ -17,8 +17,9 @@ using UnityEngine;
             //TileManager.Instance.BlockCollider();
         }
 
-        // Update is called once per frame
-        void Update()
+
+    // Update is called once per frame
+    void Update()
         {
             if(Input.GetKeyDown(KeyCode.F1))
             {

--- a/Assets/Scripts/HexPack/Grid/GridManager.cs
+++ b/Assets/Scripts/HexPack/Grid/GridManager.cs
@@ -52,7 +52,7 @@ using Random = UnityEngine.Random;
         /// <summary>
         /// <paramref name="type"/>에 해당하는 모든 타일을 배열타입으로 가져온다
         /// </summary>
-        public List<Tile> GetHexagonTiles(TileItem.eType type)
+        public List<Tile> GetHexagonTiles(TileItem.eCampType type)
         {
             List<Tile> result = new List<Tile>();
 

--- a/Assets/Scripts/HexPack/Grid/Tile.cs
+++ b/Assets/Scripts/HexPack/Grid/Tile.cs
@@ -5,8 +5,9 @@ using TMPro;
     {
         [SerializeField] SpriteRenderer render;
         [SerializeField] TileItem item;
+        public bool playerCamp;
         public TMP_Text tmp;
-
+        
         private void Awake()
         {
             tmp = GetComponentInChildren<TMP_Text>();
@@ -34,7 +35,7 @@ using TMPro;
             
         }
 
-        public TileItem.eType GeteType()
+        public TileItem.eCampType GeteType()
         {
             return item.type;
         }

--- a/Assets/Scripts/HexPack/Pathfinder/PathFindingManager.cs
+++ b/Assets/Scripts/HexPack/Pathfinder/PathFindingManager.cs
@@ -136,7 +136,7 @@ public class PathFindingManager : Singleton<PathFindingManager>
         {
             if(targetNode.unit != null  && targetNode.unit.onLive)
             {
-                UnitManager.Instance.SetTargetUnit(targetNode.unit);
+                UnitManager.Instance.ActiveUnit(targetNode.unit);
             }
             return;
             
@@ -144,7 +144,7 @@ public class PathFindingManager : Singleton<PathFindingManager>
 
         if(FinalList.Count == 0)
         {
-            UnitManager.Instance.SetTargetUnit(targetNode.unit);
+            UnitManager.Instance.ActiveUnit(targetNode.unit);
             //이웃한 노드를 선택했을시 FinalList는 존재하지않기때문에 문제가 발생한다
             //이경우 바로 이벤트가 이러나게끔한다
             return;

--- a/Assets/Scripts/HexPack/Unit/UnitManager.cs
+++ b/Assets/Scripts/HexPack/Unit/UnitManager.cs
@@ -26,7 +26,12 @@ public class UnitManager : Singleton<UnitManager>
 
     public void CreatePlayer()
     {
-        var baseNode = GridManager.Instance.GetHaxgonTile(0,0);
+
+        var hexagonGrid = GridManager.Instance.hexagonGrid;
+        int playerPosX = hexagonGrid.width  /2;
+        int playerPosY = hexagonGrid.hegiht /2;
+
+        var baseNode = GridManager.Instance.GetHaxgonTile(playerPosX,playerPosY);
         Vector2 pos = baseNode.transform.position;
         Vector3 vec = new Vector3(pos.x, pos.y + Offset, 0f);
         var go = Instantiate(playerPrefab, vec, Util.QI);
@@ -44,15 +49,15 @@ public class UnitManager : Singleton<UnitManager>
     /// </summary>
     public void UnitGenerator()
     {
-        foreach(TileItem.eType enumItem in  Enum.GetValues(typeof(TileItem.eType)))
+        foreach(TileItem.eCampType enumItem in  Enum.GetValues(typeof(TileItem.eCampType)))
         {
             switch(enumItem)
             {
                 //해당 타입은 모두 반드시 유닛이 있어야한다.
-                case TileItem.eType.Mountain:
-                case TileItem.eType.Volcano:
-                case TileItem.eType.PlainsCastle:
-                case TileItem.eType.Plains:
+                case TileItem.eCampType.Mountain:
+                case TileItem.eCampType.Volcano:
+                //case TileItem.eCampType.PlainsCastle:
+                case TileItem.eCampType.Plains:
                     Unitcomport(enumItem);
                     break;
             }
@@ -60,11 +65,13 @@ public class UnitManager : Singleton<UnitManager>
 
 
     }
+
+
     /// <summary>
     /// 가져온 타일의 타입에 맞게 처신하여 유닛새성을 돕는다
     /// </summary>
     /// <param name="type"></param>는 유닛의 부모이다
-    private void Unitcomport(TileItem.eType type)
+    private void Unitcomport(TileItem.eCampType type)
     {
         var tiles = GridManager.Instance.GetHexagonTiles(type);
 
@@ -73,17 +80,17 @@ public class UnitManager : Singleton<UnitManager>
         {
             switch (tile.GeteType())
             {
-                case TileItem.eType.Mountain:
+                case TileItem.eCampType.Mountain:
                     UnitCreator<Creature>(tile, savagesUnitSO , true);
                     break;
-                case TileItem.eType.Volcano:
+                case TileItem.eCampType.Volcano:
                     UnitCreator<Creature>(tile, bossUnitSO, true);
                     break;
-                case TileItem.eType.Forest:
-                case TileItem.eType.PlainsCastle:
+                case TileItem.eCampType.Forest:
+                case TileItem.eCampType.PlainsCastle:
                     UnitCreator<Creature>(tile, hidingUnitSO, false);
                     break;
-                case TileItem.eType.Plains:
+                case TileItem.eCampType.Plains:
                     UnitCreator<Tower>(tile, towerUnitSO , true);
                     break;
 
@@ -107,11 +114,13 @@ public class UnitManager : Singleton<UnitManager>
         
     }
 
-    public void SetTargetUnit(Unit unit)
+    public void ActiveUnit(Unit unit)
     {
         targetUnit = unit;
+        Debug.Log($"Action {unit}");
 
-        QuestManager.Instance.CreateQuest(targetUnit.item.questType);
+        //퀘스트 매니저 필요없을수도 있
+        //QuestManager.Instance.CreateQuest(targetUnit.item.questType);
     }
 
     public void TargetUnitRelese()


### PR DESCRIPTION
2. 가로 사이즈 수정
3. 헥사타일 SetTileAttribute 로직 수정
 - CreateCampCount. ->. 맵 생성에 존재하는 속성타일 버퍼 생성 서비스
 - DrawTile 버퍼데이터를 매개값으로 타일의 드로잉을 서비스한다
 - [변수] PlayerCamp -> 해당 타일이 플레이어 거점의 좌표인지 true로 알려준다.
4. UnitManager 함수 수정
 - CreatePlayer() 기존 0,0좌표에서 생성된 좌표를 with /2 , hegiht / 2 좌표로 수정
5. SetTargetUnit() -> ActiveUnit() 이름 수정
 - 타겟유닛을 지정하는 함수에서 유팃의 Active를 처리하는 함수로 수정
 - CreateQust 함수 드랍